### PR TITLE
Improvements

### DIFF
--- a/1.3/Languages/English/Keyed/SomeFood.xml
+++ b/1.3/Languages/English/Keyed/SomeFood.xml
@@ -4,6 +4,7 @@
   <SomeFoodDesc>Food is not of an immediate concern.\n\n    Full bars worth of food in storage: {0}\n    Colonists/prisoners getting food: {1}\n    Days worth of food in storage: {2}</SomeFoodDesc>
   <SomeFoodDescNew>Food is not of an immediate concern.\n\n    Full bars worth of food in storage: {0}\n    Colonists/prisoners getting food: {1}\n    Amount of food eaten per day: {2}\n    Days worth of food in storage: {3}</SomeFoodDescNew>
   <LowFoodDescNew>Food is a concern.\n\n    Full bars worth of food in storage: {0}\n    Colonists/prisoners getting food: {1}\n    Amount of food eaten per day: {2}\n    Days worth of food in storage: {3}</LowFoodDescNew>
+  <LowFoodAddendum>\nFood of lower preferability may be available</LowFoodAddendum>
   <FoodAlert_DaysOfFood> days worth of food</FoodAlert_DaysOfFood>
   <FoodAlert_Decent>\n\nThat is a decent amount of food.</FoodAlert_Decent>
   <FoodAlert_Poor>\n\nThat is a poor amount of food.</FoodAlert_Poor>

--- a/1.3/Languages/Italian/Keyed/SomeFood.xml
+++ b/1.3/Languages/Italian/Keyed/SomeFood.xml
@@ -4,6 +4,7 @@
   <SomeFoodDesc>Il cibo non è un problema immediato.\n\n    Barre equivalenti di cibo in dispensa: {0}\n    Coloni/prigionieri da sfamare: {1}\n    Giorni di cibo in dispensa: {2}</SomeFoodDesc>
   <SomeFoodDescNew>Il cibo non è un problema immediato.\n\n    Barre equivalenti di cibo in dispensa: {0}\n    Coloni/prigionieri da sfamare: {1}\n    Quantità di cibo consumata al giorno: {2}\n    Giorni di cibo in dispensa: {3}</SomeFoodDescNew>
   <LowFoodDescNew>Il cibo è un problema.\n\n    Barre equivalenti di cibo in dispensa: {0}\n    Coloni/prigionieri da sfamare: {1}\n    Quantità di cibo consumata al giorno: {2}\n    Giorni di cibo in dispensa: {3}</LowFoodDescNew>
+  <LowFoodAddendum>\nPotrebbe essere disponibile cibo con una preferenza più bassa</LowFoodAddendum>
   <FoodAlert_DaysOfFood> giorni di cibo</FoodAlert_DaysOfFood>
   <FoodAlert_Decent>\n\nÈ una discreta quantità di cibo.</FoodAlert_Decent>
   <FoodAlert_Poor>\n\nÈ una misera quantità di cibo.</FoodAlert_Poor>

--- a/Source/FoodAlert/HarmonyPatches.cs
+++ b/Source/FoodAlert/HarmonyPatches.cs
@@ -61,7 +61,9 @@ namespace FoodAlert
         {
             var map = Find.CurrentMap;
 
-            if (map == null || !map.IsPlayerHome && !IsSosLoaded)
+            if (map == null ||
+                !map.IsPlayerHome && !IsSosLoaded ||
+                map.IsPlayerHome && map.mapPawns.AnyColonistSpawned && map.resourceCounter.TotalHumanEdibleNutrition < 4f * map.mapPawns.FreeColonistsSpawnedCount) //Vanilla low food alert condition)
             {
                 return;
             }
@@ -130,27 +132,17 @@ namespace FoodAlert
 
                 case { } n when n >= 0:
 
-                    if (map.IsPlayerHome &&
-                        map.mapPawns.AnyColonistSpawned &&
-                        map.resourceCounter.TotalHumanEdibleNutrition < 4f * map.mapPawns.FreeColonistsSpawnedCount) //Vanilla low food alert condition
-                    {
-                        //there's already the vanilla LowFoodAlert displayed -> hide our Alert
-                        return;
-                    }
-                    else
-                    {
-                        /* there's food but since there's no vanilla alert active, probably we are counting food with an higher preferability
-                         * in any case, let's dispaly at least a poor food alert 
-                         */
-                        addendumForFlavour += "FoodAlert_Poor".Translate();
+                    /* there's food but since there's no vanilla alert active, probably we are counting food with an higher preferability
+                     * in any case, let's dispaly at least a poor food alert 
+                     */
+                    addendumForFlavour += "FoodAlert_Poor".Translate();
 
-                        if (selectedPreferabilityEnum > FoodPreferability.DesperateOnly) 
-                        {
-                            // and a warning that more food may be available
-                            addendumForFlavour += "LowFoodAddendum".Translate();
-                        }
-
+                    if (selectedPreferabilityEnum > FoodPreferability.DesperateOnly)
+                    {
+                        // and a warning that more food may be available
+                        addendumForFlavour += "LowFoodAddendum".Translate();
                     }
+
                     break;
                 default:
                     return;

--- a/Source/FoodAlert/HarmonyPatches.cs
+++ b/Source/FoodAlert/HarmonyPatches.cs
@@ -28,7 +28,7 @@ namespace FoodAlert
             var selectedPreferability = LoadedModManager.GetMod<FoodAlertMod>().GetSettings<FoodAlertSettings>()
                 .foodPreferability;
             var selectedPreferabilityEnum =
-                (FoodPreferability) Enum.Parse(typeof(FoodPreferability), selectedPreferability);
+                (FoodPreferability)Enum.Parse(typeof(FoodPreferability), selectedPreferability);
             foreach (var keyValuePair in map.resourceCounter.AllCountedAmounts)
             {
                 if (keyValuePair.Value <= 0)
@@ -94,9 +94,13 @@ namespace FoodAlert
             //    return;
 
 
+            var selectedPreferability = LoadedModManager.GetMod<FoodAlertMod>().GetSettings<FoodAlertSettings>()
+               .foodPreferability;
+            var selectedPreferabilityEnum =
+                (FoodPreferability)Enum.Parse(typeof(FoodPreferability), selectedPreferability);
+
             string addendumForFlavour = "\n    " + "SettingDescription".Translate() + ": " +
-                                        LoadedModManager.GetMod<FoodAlertMod>().GetSettings<FoodAlertSettings>()
-                                            .foodPreferability;
+                                        selectedPreferability;
             if (CachedNeed == 0f)
             {
                 addendumForFlavour = "\n\nTotal food-need is 0, that shouldnt happen.";
@@ -123,8 +127,30 @@ namespace FoodAlert
                 case { } n when n >= 4:
                     addendumForFlavour += "FoodAlert_Decent".Translate();
                     break;
-                case { } n when n >= 1:
-                    addendumForFlavour += "FoodAlert_Poor".Translate();
+
+                case { } n when n >= 0:
+
+                    if (map.IsPlayerHome &&
+                        map.mapPawns.AnyColonistSpawned &&
+                        map.resourceCounter.TotalHumanEdibleNutrition < 4f * map.mapPawns.FreeColonistsSpawnedCount) //Vanilla low food alert condition
+                    {
+                        //there's already the vanilla LowFoodAlert displayed -> hide our Alert
+                        return;
+                    }
+                    else
+                    {
+                        /* there's food but since there's no vanilla alert active, probably we are counting food with an higher preferability
+                         * in any case, let's dispaly at least a poor food alert 
+                         */
+                        addendumForFlavour += "FoodAlert_Poor".Translate();
+
+                        if (selectedPreferabilityEnum > FoodPreferability.DesperateOnly) 
+                        {
+                            // and a warning that more food may be available
+                            addendumForFlavour += "LowFoodAddendum".Translate();
+                        }
+
+                    }
                     break;
                 default:
                     return;


### PR DESCRIPTION
Hide mod alert if vanilla alert is already displayed
Add some logic to manage cases where there's food available but we have set an higher preferability: this caused the "day of food available" to become <1 -> food alert NOT displayed -> user not aware that preferred food is not available any more

Tested on several different scenarios and it seems to work correctly